### PR TITLE
Rotate image

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	Nth        int
 	Repeat     int
 	Filter     int
+	Rotation   float64
 	V, VV      bool
 )
 
@@ -78,6 +79,7 @@ func init() {
 	flag.IntVar(&Nth, "nth", 1, "save every Nth frame (put \"%d\" in path)")
 	flag.IntVar(&Repeat, "rep", 0, "add N extra shapes per iteration with reduced search")
 	flag.IntVar(&Filter, "f", 0, "0=no filter 1=gray scale 2=sepia 3=negative")
+	flag.Float64Var(&Rotation, "rot", 0, "degree of rotation for the output image")
 	flag.BoolVar(&V, "v", false, "verbose")
 	flag.BoolVar(&VV, "vv", false, "very verbose")
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"flag"
 	"fmt"
+	"image/color"
 	"log"
 	"math/rand"
 	"os"
@@ -14,9 +15,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/disintegration/imaging"
 	"github.com/fogleman/primitive/primitive"
 	"github.com/nfnt/resize"
-	"github.com/disintegration/imaging"
 )
 
 var (
@@ -199,9 +200,9 @@ func main() {
 					default:
 						check(fmt.Errorf("unrecognized file extension: %s", ext))
 					case ".png":
-						check(primitive.SavePNG(path, model.Context.Image()))
+						check(primitive.SavePNG(path, imaging.Rotate(model.Context.Image(), Rotation, color.Black)))
 					case ".jpg", ".jpeg":
-						check(primitive.SaveJPG(path, model.Context.Image(), 95))
+						check(primitive.SaveJPG(path, imaging.Rotate(model.Context.Image(), Rotation, color.Black), 95))
 					case ".svg":
 						check(primitive.SaveFile(path, model.SVG()))
 					case ".gif":

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/fogleman/primitive/primitive"
 	"github.com/nfnt/resize"
+	"github.com/disintegration/imaging"
 )
 
 var (


### PR DESCRIPTION
added an option to allow the user to output an image. If the image is rotated to a degree besides, 0, 90, 180 or 360, it causes there to be blank space so i filled in the space to be black. When running the code, you may need to run "go get -u github.com/disintegration/imaging" in order for it to compile.