### PR TITLE
Calling Main.go instead Reduces Errors

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -142,7 +142,8 @@ def makePhoto():
         outputPath = outputPath + "/" + filenameEntry.get() + selectedExtension.get()
         print("This is outputPath " + outputPath)
         print("This is inputPath " + inputPath)
-        os.system("primitive -f %s -a %s -i %s -o %s -n %s -j %s -m %s" %(filter,alphaInput,inputPath,outputPath, numShapesInput, numWorkers, mode))
+        os.system("go run main.go -f %s -a %s -i %s -o %s -n %s -j %s -m %s" %(filter,alphaInput,inputPath,outputPath, numShapesInput, numWorkers, mode))
+        
         return
             
     except OSError as e:

--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 
 			// find optimal shape and add it to the model
 			t := time.Now()
-			n := model.Step(primitive.ShapeType(config.Mode), config.Alpha, config.Repeat, config.Filter)
+			n := model.Step(primitive.ShapeType(config.Mode), config.Alpha, config.Repeat)
 			nps := primitive.NumberString(float64(n) / time.Since(t).Seconds())
 			elapsed := time.Since(start).Seconds()
 			primitive.Log(1, "%d: t=%.3f, score=%.6f, n=%d, n/s=%s\n", frame, elapsed, model.Score, n, nps)


### PR DESCRIPTION
Some operating systems have a hard time running primitive so calling main.go helps reduce this occurence. 